### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Apple Notes Model Context Protocol Server for Claude Desktop.
+[![smithery badge](https://smithery.ai/badge/apple-notes-mcp)](https://smithery.ai/server/apple-notes-mcp)
 
 Read your local Apple Notes database and provide it to Claude Desktop.
 
@@ -29,6 +30,14 @@ The server provides multiple prompts:
 - No ability to create or edit notes
 
 ## Quickstart
+
+### Installing via Smithery
+
+To install Apple Notes Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/apple-notes-mcp):
+
+```bash
+npx -y @smithery/cli install apple-notes-mcp --client claude
+```
 
 ### Install the server
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Apple Notes Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/apple-notes-mcp

Let me know if any tweaks have to be made!